### PR TITLE
ゲスト登録機能修正、ボケとツッコミが改行されるように修正

### DIFF
--- a/app/controllers/users_jokes_controller.rb
+++ b/app/controllers/users_jokes_controller.rb
@@ -25,16 +25,20 @@ class UsersJokesController < ApplicationController
   end
 
   def show
-    user = User.find_or_create_by!(email: 'guest@changeguest.com', name: 'ゲスト') do |user|
-      user.password = SecureRandom.urlsafe_base64
-      # user.confirmed_at = Time.now  # Confirmable を使用している場合は必要
+    if current_user.nil?
+      user = User.find_or_create_by!(email: 'guest@changeguest.com', name: 'ゲスト') do |user|
+        user.password = SecureRandom.urlsafe_base64
+        # user.confirmed_at = Time.now  # Confirmable を使用している場合は必要
+      end
+    else
+      user = current_user
     end
     sign_in user
 
     @genre = Genre.find(params[:id])
     @joke_book = JokeBook.new
     @joke_book.name = @genre.name
-    @joke_book.user_id = current_user.id
+    @joke_book.user_id = user.id
     if @joke_book.save
       redirect_to users_jokes_joke_first_path(joke_book_id: @joke_book.id, genre_id: @genre.id)
       # ここに引数で@joke_bookでjoke_bookIDを渡せれば

--- a/app/views/users_jokes/joke_first.html.erb
+++ b/app/views/users_jokes/joke_first.html.erb
@@ -30,13 +30,13 @@
          <%=f.radio_button :users_joke, adminsjoke.funny_man + "," + adminsjoke.straight_man,id:"users_joke_#{index}" %>
 
         <%=f.label :users_joke,
-        "#{adminsjoke.funny_man}　　#{adminsjoke.straight_man}",for:"users_joke_#{index}"%>
+        "#{adminsjoke.funny_man}<br>#{adminsjoke.straight_man}".html_safe,for:"users_joke_#{index}"%>
         </div>
         <br>
 
 
         <% end %>
-        <%= f.submit"次へ" %>
+        <%= f.submit('次へ',class: 'btn btn-primary btn-lg')%>
         <% end %>
 
       </div>

--- a/app/views/users_jokes/joke_last.html.erb
+++ b/app/views/users_jokes/joke_last.html.erb
@@ -24,8 +24,9 @@
         <div class="boke">
           <%=f.radio_button :users_joke, adminsjoke.funny_man + "," + adminsjoke.straight_man,id:"users_joke_#{index}" %>
 
-         <%=f.label :users_joke,
-         "#{adminsjoke.funny_man}　　#{adminsjoke.straight_man}",for:"users_joke_#{index}"%>
+          <%=f.label :users_joke,
+          "#{adminsjoke.funny_man}<br>#{adminsjoke.straight_man}".html_safe,for:"users_joke_#{index}"%>
+          </div>
          </div>
          <br>
 

--- a/app/views/users_jokes/joke_middle.html.erb
+++ b/app/views/users_jokes/joke_middle.html.erb
@@ -27,8 +27,9 @@
         <div class="boke">
           <%=f.radio_button :users_joke, adminsjoke.funny_man + "," + adminsjoke.straight_man,id:"users_joke_#{index}" %>
 
-         <%=f.label :users_joke,
-         "#{adminsjoke.funny_man}　　#{adminsjoke.straight_man}",for:"users_joke_#{index}"%>
+          <%=f.label :users_joke,
+          "#{adminsjoke.funny_man}<br>#{adminsjoke.straight_man}".html_safe,for:"users_joke_#{index}"%>
+          </div>
         </div>
         <br>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   post 'inquiry' => 'inquirys#create'
   get 'inquiry/thanks' => 'inquirys#thanks'
   get 'about' => 'top#about'
+  post 'login' => 'users_jokes#login'
   post 'users_jokes/script' => 'users_jokes#script'
 
   post 'users_jokes/create' => 'users_jokes#create'


### PR DESCRIPTION
新規登録してネタを作ろうとしたら、ゲスト登録として上書きされてしまうようなコードだった為、上書きされないように修正。
ボケとツッコミが改行されず、そのまま羅列されて書かれていた為、それをhtml.safeで改行されるように修正。